### PR TITLE
Remove subfield 9 warnings

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/MarcChecker.pm
+++ b/Koha/Plugin/Com/ByWaterSolutions/MarcChecker.pm
@@ -106,7 +106,7 @@ sub report_step2 {
         push(
             @results,
             {   data     => $row,
-                warnings => \@warnings,
+                warnings => grep( !/Subfield _9/, @warnings), # TODO: Fix MARC::Lint instead
             }
         );
     }


### PR DESCRIPTION
There's no point showing warnigns that will always show because of a bug
in MARC::Lint. This is already on the TODO list for MARC::Lint.

Signed-off-by: Tomas Cohen Arazi tomascohen@theke.io
